### PR TITLE
replace tonnerre/golang-text with kr/text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/mccanne/charm
 
 require (
-	github.com/tonnerre/golang-text v0.0.0-20130925195846-048ed3d792f7
+	github.com/kr/text v0.1.0
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/tonnerre/golang-text v0.0.0-20130925195846-048ed3d792f7 h1:E4pdTAo1tqctAfTr2tkxcX+JkDeJP84bQfjC3ONwoXQ=
-github.com/tonnerre/golang-text v0.0.0-20130925195846-048ed3d792f7/go.mod h1:J5H/d3ZVtRUjmP4Zf87sPSIUSCGFXorzn3hQtdODORQ=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=

--- a/help.go
+++ b/help.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kr/text"
 	"github.com/mccanne/charm/pkg/termwidth"
-	text "github.com/tonnerre/golang-text"
 )
 
 var Help = &Spec{


### PR DESCRIPTION
The repository github.com/tonnerre/golang-text no longer exists.
According to this pr on consule it was a needless fork of
github.com/kr/text anyway: https://github.com/hashicorp/consul/issues/4269